### PR TITLE
fix: type error in createTransferBody

### DIFF
--- a/dist/types/contract/token/ft/jetton-wallet.d.ts
+++ b/dist/types/contract/token/ft/jetton-wallet.d.ts
@@ -16,7 +16,7 @@ export interface WalletData {
 }
 export interface TransferBodyParams {
     queryId?: number;
-    tokenAmount: BN;
+    jettonAmount: BN;
     toAddress: Address;
     responseAddress: Address;
     forwardAmount: BN;


### PR DESCRIPTION
This error made me waste 4 days trying to figure out why my transactions were transferring 0 amount of my jetton until i found this [Answer](https://answers.ton.org/question/1612576097562529792/zero-amount-jettons-in-transaction)
